### PR TITLE
Moved promote tool file to milo

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -32,7 +32,7 @@
       "id": "graybox-promote",
       "title": "Graybox Promote",
       "environments": ["edit"],
-      "url": "https://main--bacom-graybox--adobecom.hlx.page/tools/graybox-promote?milolibs=grayboxui",
+      "url": "https://grayboxui--milo--adobecom.hlx.page/tools/graybox-promote",
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,


### PR DESCRIPTION
This PR helps fetching the promote tool file from milo instead of bacom-graybox.