### PR TITLE
Sidekick promote config changes

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -32,11 +32,9 @@
       "id": "graybox-promote",
       "title": "Graybox Promote",
       "environments": ["edit"],
-      "url": "https://grayboxui--milo--adobecom.hlx.page/tools/graybox-promote",
-      "isPalette": true,
+      "url": "https://main--bacom-graybox--adobecom.hlx.page/tools/graybox-promote?milolibs=grayboxui",
       "passReferrer": true,
       "passConfig": true,
-      "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 498px; width: 460px;",
       "includePaths": ["*.json"]
     },
     {


### PR DESCRIPTION
This PR changes the config for the promote tool to load it in a separate window and from the bacom-graybox relevant url.